### PR TITLE
bugfix paranoiaIsHostLocal expect box brackets

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -346,7 +346,7 @@ if (typeof(tbParanoia) === "undefined") {
 		/* Return true if host is on a local network */
 		paranoiaIsHostLocal: function(hostname) {
 			if(hostname == 'localhost') return true;
-			if(hostname == '[127.0.0.1]') return true;
+			if(hostname == '127.0.0.1') return true;
 			if(hostname == 'Internal') return true;
 			if(hostname == 'www-data') return true;
 			if(/^\.internal$/g.test(hostname)) return true; 


### PR DESCRIPTION
rcvdIPRegexp will remove box brackets from ip addresses, so it should not be expected in paranoiaIsHostLocal
