### PR TITLE
Add Reddoxx SMTP-TLS header for detection

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -56,11 +56,11 @@ if (typeof(tbParanoia) === "undefined") {
 		},
 
 		paranoiaParseReceivedHeader: function(header) {
-			var secureMethods = ['SMTPS', 'ESMTPS', 'SMTPSA', 'ESMTPSA', 'AES256'];
+			var secureMethods = ['SMTPS', 'ESMTPS', 'SMTPSA', 'ESMTPSA', 'AES256', 'SMTP-TLS'];
 
 			/* Regexp definition must stay in the loop - stupid JS won't match the same regexp twice */
-			var rcvdRegexp = /^.*from\s+([^ ]+)\s+.*by ([^ ]+)\s+.*with\s+([A-Za-z0-9]+).*;.*$/g;
-			var rcvdIPRegexp = /^.*from\s+([^ ]+)\s+[^\[]+\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\].*by ([^ ]+)\s+.*with\s+([A-Za-z0-9]+).*;.*$/g;
+			var rcvdRegexp = /^.*from\s+([^ ]+)\s+.*by ([^ ]+)\s+.*with\s+([-A-Za-z0-9]+).*;.*$/g;
+			var rcvdIPRegexp = /^.*from\s+([^ ]+)\s+[^\[]+\[(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})\].*by ([^ ]+)\s+.*with\s+([-A-Za-z0-9]+).*;.*$/g;
 
 			var matchedFrom = null;
 			var matchedTo = null;


### PR DESCRIPTION
Testing our mail-system with your awesome Add-On, we found [Reddoxx](http://www.reddoxx.com/en) to use a different header than most other MTAs. This PR adds the header to the detection mechanism.
Example Header:

```
Received: from mail.example.com ( [0.0.0.0]) by mail.example.com
	(Reddoxx engine) with SMTP-TLS id FFF000FFF00; Fri, 24 Apr 2015 23:59:59 +0200
```

Tested locally and found to be working. The only regression I can think of would lie in problems originating from adding the minus sign to the regex, so something like ```SMTPS-XYZ``` wouldn't match anymore.