### PR TITLE
Add unknown type for IMAP connections

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -57,6 +57,7 @@ if (typeof(tbParanoia) === "undefined") {
 
 		paranoiaParseReceivedHeader: function(header) {
 			var secureMethods = ['SMTPS', 'ESMTPS', 'SMTPSA', 'ESMTPSA', 'AES256', 'AES128', 'SMTP-TLS'];
+			var unknownMethods = ['IMAP'];
 
 			/* Regexp definition must stay in the loop - stupid JS won't match the same regexp twice */
 			var rcvdRegexp = /^.*from\s+([^ ]+)\s+.*by ([^ ]+)\s+.*with\s+([-A-Za-z0-9]+).*;.*$/g;
@@ -102,9 +103,11 @@ if (typeof(tbParanoia) === "undefined") {
 				method: matchedMethod,
 				local: local,
 				secure: (secureMethods.indexOf(matchedMethod.toUpperCase()) != -1),
+				unknown: (unknownMethods.indexOf(matchedMethod.toUpperCase()) != -1),
 				toString: function() {
 					var secureSign = this.secure ? '✓' : '✗';
 					if(this.local) secureSign = '⌂';
+					if(unknownMethods.indexOf(matchedMethod.toUpperCase()) != -1) secureSign = '?';
 					return secureSign + ' ' + this.method + ": " + this.from + " ==> " + this.to;
 				}
 			};
@@ -209,8 +212,9 @@ if (typeof(tbParanoia) === "undefined") {
 			var encrypted = 0;
 			receivedHeaders.forEach(function(header) {
 //				Application.console.log(header.from + " - " + header.secure);
-				if(!header.secure && !header.local) insecure++;
+				if(!header.secure && !header.local && !header.unknown) insecure++;
 				if(!header.secure && header.local) unencryptedLocal++;
+				if(!header.secure && header.unknown) unencryptedLocal++;
 				if(header.secure) encrypted++;
 			});
 


### PR DESCRIPTION
I use fetchmail to get emails from an external account. The connection is using SSL, but by now paranoia rates the connection as bad.

Unfortunately, there is no information in the header, whether SSL is used or not:

```
Received: from gmail-imap.l.google.com [2a00:1450:400c:c04::6d]
    by mx.example.com with IMAP (fetchmail-6.3.26)
    for <example@example.com> (single-drop); Sun, 21 Feb 2016 16:35:02 +0100 (CET)
```

I'm not really sure how to handle this kind of connections, so this pr is just an idea.

It creates a new category besides local/secure/insecure connections. Matching
the IMAP protocol counts as an unknown connection and only increases the
unencryptedLocal counter, so the rating is not influenced by that.