### PR TITLE
Include LMTP into unknown methods list.

### DIFF
--- a/content/overlay.js
+++ b/content/overlay.js
@@ -57,7 +57,7 @@ if (typeof(tbParanoia) === "undefined") {
 
 		paranoiaParseReceivedHeader: function(header) {
 			var secureMethods = ['SMTPS', 'ESMTPS', 'SMTPSA', 'ESMTPSA', 'AES256', 'AES128', 'SMTP-TLS'];
-			var unknownMethods = ['IMAP'];
+			var unknownMethods = ['IMAP', 'LMTP'];
 
 			/* Regexp definition must stay in the loop - stupid JS won't match the same regexp twice */
 			var rcvdRegexp = /^.*from\s+([^ ]+)\s+.*by ([^ ]+)\s+.*with\s+([-A-Za-z0-9]+).*;.*$/g;


### PR DESCRIPTION
My Postfix delivers mails to the Dovecot instance running on the same server over LMTP, which is intended to be used over local networks only.

LMTP may be also encrypted as LMTPS, but the header will still only contain the 'with LMTP' keyword.
Thus, I'm adding LMTP to the unknownMethods list.